### PR TITLE
컬러칩 세팅, tailwind config 등록

### DIFF
--- a/components/colors/colors.stories.mdx
+++ b/components/colors/colors.stories.mdx
@@ -1,0 +1,155 @@
+import { Meta, ColorPalette, ColorItem } from '@storybook/blocks'
+
+<Meta title="Colors" />
+
+<ColorPalette>
+
+<ColorItem
+  title="brand"
+  subtitle="main"
+  colors={{
+    green400: '#00BC68',
+  }}
+/>
+
+<ColorItem
+  title="brand"
+  subtitle="sub1"
+  colors={{
+    yellow900: '#F77D0E',
+    yellow500: '#FFEB34',
+    blue600: '#199EF0',
+  }}
+/>
+
+<ColorItem
+  title="main"
+  subtitle="green"
+  colors={{
+    green900: '#005E16',
+    green800: '#007D2A',
+    green700: '#008E36',
+    green600: '#00A142',
+    green500: '#00B04C',
+    green400: '#00BC68',
+    green300: '#52C882',
+    green200: '#8BD7A6',
+    green100: '#BAE7C9',
+    green50: '#E2F6E9',
+  }}
+/>
+
+<ColorItem
+  title="sub1"
+  subtitle="yellow"
+  colors={{
+    yellow900: '#F77D0E',
+    yellow800: '#FAA71E',
+    yellow700: '#FCBF26',
+    yellow600: '#FDD82E',
+    yellow500: '#FFEB34',
+    yellow400: '#FCEB51',
+    yellow300: '#FCEB51',
+    yellow200: '#FFF59B',
+    yellow100: '#FFF9C3',
+    yellow50: '#FFFDE7',
+  }}
+/>
+
+<ColorItem
+  title="sub2"
+  subtitle="blue"
+  colors={{
+    blue900: '#1659A5',
+    blue800: '#1779C7',
+    blue700: '#1A8ADB',
+    blue600: '#199EF0',
+    blue500: '#18ACFF',
+    blue400: '#2DB9FF',
+    blue300: '#51C6FF',
+    blue200: '#83D6FF',
+    blue100: '#B4E6FF',
+    blue50: '#E2F5FF',
+  }}
+/>
+
+<ColorItem
+  title="gray"
+  colors={{
+    gray900: '#111111',
+    gray800: '#313131',
+    gray700: '#4F4F4F',
+    gray600: '#626262',
+    gray500: '#898989',
+    gray400: '#AAAAAA',
+    gray300: '#CFCFCF',
+    gray200: '#E1E1E1',
+    gray100: '#EEEEEE',
+    gray50: '#F7F7F7',
+  }}
+/>
+
+<ColorItem
+  title="text"
+  subtitle="main"
+  colors={{
+    black11: '#111111',
+    whiteFF: '#FFFFFF',
+  }}
+/>
+
+<ColorItem
+  title="text"
+  subtitle="sub"
+  colors={{
+    gray4f: '#4F4F4F',
+    gray76: '#767676',
+    gray99: '#999999',
+  }}
+/>
+
+<ColorItem
+  title="line"
+  colors={{
+    soft: '#F1F1F5',
+    medium: '#E5E5EC',
+  }}
+/>
+
+<ColorItem
+  title="meetingPath"
+  subtitle="만난경로 표시컬러"
+  colors={{
+    etc: '#005E16',
+    social: '#75E75B',
+    company: '#199EF0',
+    college: '#00BC68',
+    primary: '#FFEB34',
+    secondary: '#F77D0E',
+  }}
+/>
+
+<ColorItem
+  title="background"
+  subtitle="light"
+  colors={{
+    green1: '#C5E4CC',
+    green2: '#E2F6E9',
+    green3: '#ECFFE8',
+    blue1: '#E2F5FF',
+    yellow1: '#FFFDE7',
+    orange1: '#FFF1DB',
+    gray1: '#F7F7F7',
+  }}
+/>
+
+<ColorItem
+  title="inputbox"
+  subitle="color"
+  colors={{
+    alert: '#DC0000',
+    success: '#04B014',
+  }}
+/>
+
+</ColorPalette>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,15 +14,6 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <main className={pretendard.variable}>
       <Component {...pageProps} />
-      <Typography hierarchy="mainTitle1" as="h1">
-        Main Title 1
-      </Typography>
-      <Typography hierarchy="subTitle1" as="h2">
-        Sub Title 1
-      </Typography>
-      <Typography hierarchy="body1" as="div">
-        Body 1
-      </Typography>
     </main>
   )
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import { Typography } from '@/components/typography'
 import '@/styles/global.css'
 
 import type { AppProps } from 'next/app'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import Button from '@/components/button'
 import Carousel from '@/components/carousel'
 import Inputbox from '@/components/inputbox'
 import { media } from '@/components/media'
+import { Typography } from '@/components/typography'
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
@@ -26,6 +27,10 @@ const Page = () => {
       <Link href="/signin">
         <Button>Signin</Button>
       </Link>
+
+      <Typography hierarchy="mainTitle1" as="h1">
+        Main Title 1
+      </Typography>
     </div>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,6 +31,14 @@ const Page = () => {
       <Typography hierarchy="mainTitle1" as="h1">
         Main Title 1
       </Typography>
+
+      <Typography
+        hierarchy="mainTitle2"
+        as="h2"
+        className="text-main-green-green400"
+      >
+        Main Title 2
+      </Typography>
     </div>
   )
 }

--- a/styles/colors.js
+++ b/styles/colors.js
@@ -1,0 +1,108 @@
+const colors = {
+  brand: {
+    main: {
+      green400: '#00BC68',
+    },
+    sub1: {
+      yellow900: '#F77D0E',
+      yellow500: '#FFEB34',
+      blue600: '#199EF0',
+    },
+  },
+  main: {
+    green: {
+      green900: '#005E16',
+      green800: '#007D2A',
+      green700: '#008E36',
+      green600: '#00A142',
+      green500: '#00B04C',
+      green400: '#00BC68',
+      green300: '#52C882',
+      green200: '#8BD7A6',
+      green100: '#BAE7C9',
+      green50: '#E2F6E9',
+    },
+    sub1: {
+      yellow: {
+        yellow900: '#F77D0E',
+        yellow800: '#FAA71E',
+        yellow700: '#FCBF26',
+        yellow600: '#FDD82E',
+        yellow500: '#FFEB34',
+        yellow400: '#FCEB51',
+        yellow300: '#FCEB51',
+        yellow200: '#FFF59B',
+        yellow100: '#FFF9C3',
+        yellow50: '#FFFDE7',
+      },
+    },
+    sub2: {
+      blue: {
+        blue900: '#1659A5',
+        blue800: '#1779C7',
+        blue700: '#1A8ADB',
+        blue600: '#199EF0',
+        blue500: '#18ACFF',
+        blue400: '#2DB9FF',
+        blue300: '#51C6FF',
+        blue200: '#83D6FF',
+        blue100: '#B4E6FF',
+        blue50: '#E2F5FF',
+      },
+    },
+  },
+  gray: {
+    gray900: '#111111',
+    gray800: '#313131',
+    gray700: '#4F4F4F',
+    gray600: '#626262',
+    gray500: '#898989',
+    gray400: '#AAAAAA',
+    gray300: '#CFCFCF',
+    gray200: '#E1E1E1',
+    gray100: '#EEEEEE',
+    gray50: '#F7F7F7',
+  },
+  text: {
+    main: {
+      black11: '#111111',
+      whiteFF: '#FFFFFF',
+    },
+    sub: {
+      gray4f: '#4F4F4F',
+      gray76: '#767676',
+      gray99: '#999999',
+    },
+  },
+  line: {
+    soft: '#F1F1F5',
+    medium: '#E5E5EC',
+  },
+  meetingPath: {
+    etc: '#005E16',
+    social: '#75E75B',
+    company: '#199EF0',
+    college: '#00BC68',
+    primary: '#FFEB34',
+    secondary: '#F77D0E',
+  },
+  background: {
+    light: {
+      green1: '#C5E4CC',
+      green2: '#E2F6E9',
+      green3: '#ECFFE8',
+      blue1: '#E2F5FF',
+      yellow1: '#FFFDE7',
+      orange1: '#FFF1DB',
+      gray1: '#F7F7F7',
+    },
+  },
+  inputbox: {
+    color: {
+      alert: '#DC0000',
+      success: '#04B014',
+    },
+  },
+}
+
+export default colors

--- a/styles/theme/colors.ts
+++ b/styles/theme/colors.ts
@@ -1,4 +1,4 @@
-const colors = {
+export const colors = {
   brand: {
     main: {
       green400: '#00BC68',
@@ -105,4 +105,4 @@ const colors = {
   },
 }
 
-export default colors
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss'
+import { colors } from './styles/theme/colors'
 
 const config = {
   darkMode: ['class'],
@@ -7,6 +8,7 @@ const config = {
   theme: {
     extend: {
       colors: {
+        ...colors,
         black: 'var(--black)',
         muted: {
           DEFAULT: 'var(--muted)',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,13 @@
       "@/*": ["./*"],
     },
   },
-  "include": ["next-env.d.ts","static.d.ts", "env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": [
+    "next-env.d.ts",
+    "static.d.ts",
+    "env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "components/colors/colors.stories.mdx",
+  ],
   "exclude": ["node_modules"],
 }


### PR DESCRIPTION
### Issue No.

#12 

<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x] 1 컬러팔레트 추가
- [x] 2 tailwind config에 반영
- [x] 3 컬러칩 mdx 스토리북 추가

### 세부사항

피그마에 등록된 컬러 팔레트를 반영해두었습니다. 타이틀 명칭이 뎁스가 길어 수정이 필요해 보이긴 합니다. 이건 디자이너 분과 명칭 통일이 필요해 보이는데, 사실 저희끼리 tailiwnd만 정리해도 될 거 같아요!
너무 길다는 생각이 들어서.. ㅎㅎ 좋은 의견 있으시면 말씀해주시면 될 거 같습니다 ~


### 화면 결과 (캡쳐 첨부)

- [스토리북 배포화면](https://65b25fd2ac1ead1dc673e003-qqbhstbscs.chromatic.com/?path=/docs/colors--documentation)
<img width="539" alt="image" src="https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/5daad397-91de-4546-bcd4-eb1a7ecb6b0f">


- **테스트 화면**
<img width="499" alt="image" src="https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/fcd9407c-1a43-4071-a4b0-37a3213c44a0">
<img width="559" alt="image" src="https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/b23c16a2-5ef8-48e6-b248-17d1e167fc4e">

<br/>