### PR TITLE
남의위키 내 프로그래스바, 넘버 구현

### DIFF
--- a/components/compositions/question/First.tsx
+++ b/components/compositions/question/First.tsx
@@ -1,6 +1,8 @@
 import Button from '@/components/button'
 import InputLabel from '@/components/inputLabel'
 import Inputbox from '@/components/inputbox'
+import ProgressBar, { ProgressBarProps } from '@/components/progressbar'
+
 import RadioButton from '@/components/radioButton'
 import { useFunnelContext } from '@/contexts/useFunnelContext'
 import FormLayout from '@/layout/form-layout'
@@ -9,7 +11,13 @@ import { QSMockDataType } from '@/pages/surveys/questions'
 
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 
-const First = ({ data }: { data: QSMockDataType }) => {
+const First = ({
+  data,
+  progress,
+}: {
+  data: QSMockDataType
+  progress: ProgressBarProps
+}) => {
   const { toNextStep } = useFunnelContext()
   const { trigger, control } = useFormContext<QsSchemaType>()
 
@@ -20,7 +28,9 @@ const First = ({ data }: { data: QSMockDataType }) => {
   return (
     <>
       <FormLayout
-        title="1/2" //프로그래스바
+        title={
+          <span className="text-body1-bold text-brand-main-green400">{`${progress.current}/${progress.max}`}</span>
+        }
         button={
           <Button disabled={isDisabled} onClick={toNextStep} className="w-full">
             다음
@@ -28,13 +38,13 @@ const First = ({ data }: { data: QSMockDataType }) => {
         }
         content={
           <>
+            <ProgressBar {...progress} />
             <div className="text-left">
               <div
                 dangerouslySetInnerHTML={{
                   __html: data.title,
                 }}
               ></div>
-
               <div className="flex flex-col mt-8 space-y-2">
                 {data.options.map((option) => (
                   <Controller
@@ -57,7 +67,7 @@ const First = ({ data }: { data: QSMockDataType }) => {
                   />
                 ))}
               </div>
-              <div className="mt-60">
+              <div className="mt-44 py-2">
                 <InputLabel
                   className="text-sub2-medium"
                   label="이유를 말해주세요"

--- a/components/compositions/question/Fourth.tsx
+++ b/components/compositions/question/Fourth.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/button'
 import InputLabel from '@/components/inputLabel'
 import Inputbox from '@/components/inputbox'
+import ProgressBar, { ProgressBarProps } from '@/components/progressbar'
 import RadioButton from '@/components/radioButton'
 import FormLayout from '@/layout/form-layout'
 import { QsSchemaType } from '@/pages/surveys/hooks/useQuestionsForm'
@@ -13,7 +14,13 @@ import {
   useWatch,
 } from 'react-hook-form'
 
-const Fourth = ({ data }: { data: QSMockDataType }) => {
+const Fourth = ({
+  data,
+  progress,
+}: {
+  data: QSMockDataType
+  progress: ProgressBarProps
+}) => {
   const { handleSubmit, trigger, control } = useFormContext<QsSchemaType>()
 
   const { fourthQuestion, fourthReason } = useWatch({ control })
@@ -27,7 +34,9 @@ const Fourth = ({ data }: { data: QSMockDataType }) => {
   return (
     <>
       <FormLayout
-        title="1/2" //프로그래스바
+        title={
+          <span className="text-body1-bold text-brand-main-green400">{`${progress.current}/${progress.max}`}</span>
+        }
         button={
           <Button
             disabled={isDisabled}
@@ -39,6 +48,7 @@ const Fourth = ({ data }: { data: QSMockDataType }) => {
         }
         content={
           <>
+            <ProgressBar {...progress} />
             <div className="text-left">
               <div
                 dangerouslySetInnerHTML={{
@@ -68,7 +78,7 @@ const Fourth = ({ data }: { data: QSMockDataType }) => {
                   />
                 ))}
               </div>
-              <div className="mt-60">
+              <div className="mt-44 py-2">
                 <InputLabel
                   className="text-sub2-medium"
                   label="이유를 말해주세요"

--- a/components/compositions/question/Second.tsx
+++ b/components/compositions/question/Second.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/button'
 import InputLabel from '@/components/inputLabel'
 import Inputbox from '@/components/inputbox'
+import ProgressBar, { ProgressBarProps } from '@/components/progressbar'
 import RadioButton from '@/components/radioButton'
 import { useFunnelContext } from '@/contexts/useFunnelContext'
 import FormLayout from '@/layout/form-layout'
@@ -9,7 +10,13 @@ import { QSMockDataType } from '@/pages/surveys/questions'
 
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 
-const Second = ({ data }: { data: QSMockDataType }) => {
+const Second = ({
+  data,
+  progress,
+}: {
+  data: QSMockDataType
+  progress: ProgressBarProps
+}) => {
   const { toNextStep } = useFunnelContext()
   const { trigger, control } = useFormContext<QsSchemaType>()
 
@@ -20,7 +27,9 @@ const Second = ({ data }: { data: QSMockDataType }) => {
   return (
     <>
       <FormLayout
-        title="1/2" //프로그래스바
+        title={
+          <span className="text-body1-bold text-brand-main-green400">{`${progress.current}/${progress.max}`}</span>
+        }
         button={
           <Button disabled={isDisabled} onClick={toNextStep} className="w-full">
             다음
@@ -28,6 +37,8 @@ const Second = ({ data }: { data: QSMockDataType }) => {
         }
         content={
           <>
+            <ProgressBar {...progress} />
+
             <div className="text-left">
               <div
                 dangerouslySetInnerHTML={{
@@ -57,7 +68,7 @@ const Second = ({ data }: { data: QSMockDataType }) => {
                   />
                 ))}
               </div>
-              <div className="mt-60">
+              <div className="mt-44 py-2">
                 <InputLabel
                   className="text-sub2-medium"
                   label="이유를 말해주세요"

--- a/components/compositions/question/Third.tsx
+++ b/components/compositions/question/Third.tsx
@@ -1,6 +1,7 @@
 import Button from '@/components/button'
 import InputLabel from '@/components/inputLabel'
 import Inputbox from '@/components/inputbox'
+import ProgressBar, { ProgressBarProps } from '@/components/progressbar'
 import RadioButton from '@/components/radioButton'
 import { useFunnelContext } from '@/contexts/useFunnelContext'
 import FormLayout from '@/layout/form-layout'
@@ -9,7 +10,13 @@ import { QSMockDataType } from '@/pages/surveys/questions'
 
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
 
-const Third = ({ data }: { data: QSMockDataType }) => {
+const Third = ({
+  data,
+  progress,
+}: {
+  data: QSMockDataType
+  progress: ProgressBarProps
+}) => {
   const { toNextStep } = useFunnelContext()
   const { trigger, control } = useFormContext<QsSchemaType>()
 
@@ -20,7 +27,9 @@ const Third = ({ data }: { data: QSMockDataType }) => {
   return (
     <>
       <FormLayout
-        title="1/2" //프로그래스바
+        title={
+          <span className="text-body1-bold text-brand-main-green400">{`${progress.current}/${progress.max}`}</span>
+        }
         button={
           <Button disabled={isDisabled} onClick={toNextStep} className="w-full">
             다음
@@ -28,6 +37,7 @@ const Third = ({ data }: { data: QSMockDataType }) => {
         }
         content={
           <>
+            <ProgressBar {...progress} />
             <div className="text-left">
               <div
                 dangerouslySetInnerHTML={{
@@ -57,7 +67,7 @@ const Third = ({ data }: { data: QSMockDataType }) => {
                   />
                 ))}
               </div>
-              <div className="mt-60">
+              <div className="mt-44 py-2">
                 <InputLabel
                   className="text-sub2-medium"
                   label="이유를 말해주세요"

--- a/components/funnel/index.tsx
+++ b/components/funnel/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 interface FunnelProps<T extends readonly string[]> {
   step: T[number]
@@ -33,9 +33,11 @@ export const Step = <T extends readonly string[]>({
   children,
   onEnter,
 }: StepProps<T>) => {
-  if (onEnter) {
-    onEnter()
-  }
+  useEffect(() => {
+    if (onEnter) {
+      onEnter()
+    }
+  }, [])
 
   return <>{children}</>
 }

--- a/components/progressbar/index.tsx
+++ b/components/progressbar/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export interface ProgressBarProps {
+  current: number
+  max: number
+}
+
+const ProgressBar: React.FC<ProgressBarProps> = ({ current, max }) => {
+  return (
+    <div className="py-1 mb-4">
+      <div className="w-full h-2 bg-gray-200 rounded-lg">
+        <div
+          className="h-full bg-brand-main-green400 rounded-lg"
+          style={{ width: `${(current / max) * 100}%` }}
+        ></div>
+      </div>
+    </div>
+  )
+}
+
+export default ProgressBar

--- a/constants.ts
+++ b/constants.ts
@@ -5,3 +5,5 @@ export const AUTH = {
   OAUTH_TOKEN: 'oauthAccessToken',
   OAUTH_PROVIDER: 'oauthProvider',
 }
+
+export const QUESTION_MAX = 14

--- a/pages/surveys/questions/index.tsx
+++ b/pages/surveys/questions/index.tsx
@@ -1,9 +1,11 @@
-import First from '@/components/compositions/question/First'
-import createFunnel from '@/components/funnel/createFunnel'
-import { FunnelProvider } from '@/contexts/useFunnelContext'
-import { ReactNode } from 'react'
-import useQuestionForm from '../hooks/useQuestionsForm'
+import { ReactNode, useState } from 'react'
 import { FormProvider } from 'react-hook-form'
+
+import { FunnelProvider } from '@/contexts/useFunnelContext'
+import createFunnel from '@/components/funnel/createFunnel'
+import useQuestionForm from '../hooks/useQuestionsForm'
+
+import First from '@/components/compositions/question/First'
 import Second from '@/components/compositions/question/Second'
 import Third from '@/components/compositions/question/Third'
 import Fourth from '@/components/compositions/question/Fourth'
@@ -268,6 +270,11 @@ export type QSMockDataType = (typeof questionMockData)['data'][number]
 const Page = () => {
   const { step, toPrevStep, toNextStep } = useFunnel()
 
+  const [progress, setProgress] = useState<{ current: number; max: number }>({
+    current: 0,
+    max: 5,
+  })
+
   const questionForm = useQuestionForm()
 
   return (
@@ -283,37 +290,37 @@ const Page = () => {
             <Step
               name="1번"
               onEnter={() => {
-                //프로그래스바 진척도
+                setProgress({ current: 1, max: 5 })
               }}
             >
-              <First data={questionMockData.data[0]} />
+              <First data={questionMockData.data[0]} progress={progress} />
             </Step>
 
             <Step
               name="2번"
               onEnter={() => {
-                //프로그래스바 진척도
+                setProgress({ current: 2, max: 5 })
               }}
             >
-              <Second data={questionMockData.data[1]} />
+              <Second data={questionMockData.data[1]} progress={progress} />
             </Step>
 
             <Step
               name="3번"
               onEnter={() => {
-                //프로그래스바 진척도
+                setProgress({ current: 3, max: 5 })
               }}
             >
-              <Third data={questionMockData.data[2]} />
+              <Third data={questionMockData.data[2]} progress={progress} />
             </Step>
 
             <Step
               name="4번"
               onEnter={() => {
-                //프로그래스바 진척도
+                setProgress({ current: 4, max: 5 })
               }}
             >
-              <Fourth data={questionMockData.data[3]} />
+              <Fourth data={questionMockData.data[3]} progress={progress} />
             </Step>
 
             {/* <Step

--- a/pages/surveys/questions/index.tsx
+++ b/pages/surveys/questions/index.tsx
@@ -9,6 +9,7 @@ import First from '@/components/compositions/question/First'
 import Second from '@/components/compositions/question/Second'
 import Third from '@/components/compositions/question/Third'
 import Fourth from '@/components/compositions/question/Fourth'
+import { QUESTION_MAX } from '@/constants'
 
 const { Funnel, Step, useFunnel } = createFunnel([
   '1번',
@@ -272,7 +273,7 @@ const Page = () => {
 
   const [progress, setProgress] = useState<{ current: number; max: number }>({
     current: 0,
-    max: 5,
+    max: QUESTION_MAX,
   })
 
   const questionForm = useQuestionForm()
@@ -290,7 +291,7 @@ const Page = () => {
             <Step
               name="1번"
               onEnter={() => {
-                setProgress({ current: 1, max: 5 })
+                setProgress({ current: 1, max: QUESTION_MAX })
               }}
             >
               <First data={questionMockData.data[0]} progress={progress} />
@@ -299,7 +300,7 @@ const Page = () => {
             <Step
               name="2번"
               onEnter={() => {
-                setProgress({ current: 2, max: 5 })
+                setProgress({ current: 2, max: QUESTION_MAX })
               }}
             >
               <Second data={questionMockData.data[1]} progress={progress} />
@@ -308,7 +309,7 @@ const Page = () => {
             <Step
               name="3번"
               onEnter={() => {
-                setProgress({ current: 3, max: 5 })
+                setProgress({ current: 3, max: QUESTION_MAX })
               }}
             >
               <Third data={questionMockData.data[2]} progress={progress} />
@@ -317,7 +318,7 @@ const Page = () => {
             <Step
               name="4번"
               onEnter={() => {
-                setProgress({ current: 4, max: 5 })
+                setProgress({ current: 4, max: QUESTION_MAX })
               }}
             >
               <Fourth data={questionMockData.data[3]} progress={progress} />


### PR DESCRIPTION
### Issue No.

#41 

<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x] 1 프로그래스 바 컴포넌트 구현
- [x] 2 헤더 및 폼레이아웃에 프로그래스 진척 사항 연결
- [x] 3 maxValue 설정

### 세부사항

페이지 스텝을 1번, 2번 ~~,, 14번 형태로 네이밍할 예정이라 map 으로 간결하게 렌더링 하려했으나,, Funnel 내 Step Interface를 readonly로 할당하기 때문에  string으로 사용하는게 자유로운 형태일 거 같아 수정하지 않았습니다. 
설문 타입에 따라 넘겨주는 값도 다를 거기 때문에 일단  5-9번 다시선다 부분 진행하고 수정사항 생기면 반영해두도록 하겠습니다.

### 화면 결과 (캡쳐 첨부)


https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/7855cff0-799e-4255-b449-bfe49f812987

