### PR TITLE
feat: 설문생성 시 닉네임 글자수 제한

### DIFF
--- a/components/survey/survey-form.tsx
+++ b/components/survey/survey-form.tsx
@@ -324,6 +324,7 @@ const SurveyForm = ({
                           placeholder="15글자 이내로 입력해주세요"
                           maxLength={15}
                           type="text"
+                          inputMode="numeric"
                           value={numericString}
                           onChange={(e) => {
                             const newValue = inputPriceFormat(e.target.value)

--- a/hooks/useQuestionsForm.ts
+++ b/hooks/useQuestionsForm.ts
@@ -48,7 +48,7 @@ export interface QuestionFormValuesProps {
 
 const QsSchema = z.object({
   owner: z.string().uuid(),
-  senderName: z.string().min(1),
+  senderName: z.string().min(2).max(6),
   period: z.enum(period),
   relation: z.enum(relation),
   answers: z.array(

--- a/pages/surveys/questions/index.tsx
+++ b/pages/surveys/questions/index.tsx
@@ -296,6 +296,7 @@ const Question = ({ nickname }: { nickname: string }) => {
                         <Inputbox
                           {...field}
                           placeholder="이름을 입력해주세요"
+                          minLength={2}
                           maxLength={6}
                         />
                         <p


### PR DESCRIPTION
### Issue No.

NW-3

<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x] 1 설문 생성 닉네임 입력 글자수를 2-6자로제한
- [x] 2 모바일 - 돈 직접입력 시 숫자키보드 노출