### PR TITLE
fix: 파이차트 애니메이션 옵저버 복구

### DIFF
--- a/components/compositions/dashboard/best-worth/index.tsx
+++ b/components/compositions/dashboard/best-worth/index.tsx
@@ -125,7 +125,7 @@ const RenderActiveShape = (props: PieSectorDataItem) => {
 function BestWorth({ filter }: { filter: FilterType }) {
   const { ref, inView } = useInViewRef<HTMLDivElement>({
     once: true,
-    amount: 'all',
+    margin: '2%',
   })
 
   const { data: statisics, isLoading } = useQuery({
@@ -152,7 +152,7 @@ function BestWorth({ filter }: { filter: FilterType }) {
   }, [statisics])
 
   return (
-    <div className="w-full h-full flex flex-col">
+    <div ref={ref} className="w-full h-full flex flex-col">
       {isLoading ? (
         <>
           <div className="text-mainTitle2-bold font-bold h-8 skeleton w-3/4" />
@@ -170,10 +170,7 @@ function BestWorth({ filter }: { filter: FilterType }) {
             </b>
             이네요
           </h2>
-          <div
-            ref={ref}
-            className="flex justify-center py-12 items-center rounded-2xl shadow-basic mt-8 flex-col px-6"
-          >
+          <div className="flex justify-center py-12 items-center rounded-2xl shadow-basic mt-8 flex-col px-6">
             <div className="w-[180px] h-[180px] mx-auto relative">
               {inView && (
                 <ResponsiveContainer width="100%" height="100%">


### PR DESCRIPTION
### Issue No.


### 작업 내역

> 구현 사항 및 작업 내역

- [ ] 1 파이차트 옵저버 기존코드로 복구
- [ ] 2
- [ ] 3

### 세부사항

QA과정 중 파이차트 미노출 이슈 해결을 위해 적용해 뒀던 코드입니다.
이슈원인이 `직접입력만 있을 때`로 확인되어 기존코드를 복구했습니다.