### PR TITLE
[NW-21] 로그인 이후 화면 처리용 csrf 추가

### DIFF
--- a/pages/api/auth/[provider].ts
+++ b/pages/api/auth/[provider].ts
@@ -31,7 +31,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     // FIXME: 개발, 운영 분리 코드가 상당히 지저분함 함수화 할수 있을듯
     const { accessToken, refreshToken, errorCode, ...rest } =
       await response.json()
-
     if (errorCode === 'NOT_FOUND_USER') {
       const cookies = response.headers.getSetCookie().map(
         (cookie) =>
@@ -87,7 +86,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         maxAge: AUTH.REFRESH_EXPIRED_TIME,
       }),
     ])
-    res.status(200).redirect(`/csrf?${AUTH.LOGIN_REDIRECT_URL}=/garden`)
+    res.status(200).redirect('/csrf')
   } catch (err) {
     const error = isNamuiError(err) ? err : new InternalServerError()
     res.status(307).redirect(307, `/?err=${error.name}`)

--- a/pages/surveys/index.tsx
+++ b/pages/surveys/index.tsx
@@ -11,10 +11,15 @@ import SurveyTree from '@/components/svgs/survey-tree'
 import Modal from '@/components/modal'
 import { Close } from '@radix-ui/react-dialog'
 import Link from 'next/link'
+import { useMutation } from '@tanstack/react-query'
 
 const Page = ({ nickname, wikiId }: { nickname: string; wikiId: string }) => {
   const { signin, data } = useSession()
   const router = useRouter()
+  const { isPending, mutate } = useMutation({
+    mutationKey: ['signup'],
+    mutationFn: signin,
+  })
 
   const [openMineAlert, setOpenMineAlert] = useState(false)
 
@@ -71,9 +76,10 @@ const Page = ({ nickname, wikiId }: { nickname: string; wikiId: string }) => {
           <Button onClick={handleStart}>시작하기</Button>
         ) : (
           <Button
+            disabled={isPending}
             variant="kakao"
             onClick={() =>
-              signin({
+              mutate({
                 provider: 'kakao',
                 callbackUrl: `/surveys/questions?wikiId=${router.query.wikiId}`,
               })

--- a/provider/session-provider.tsx
+++ b/provider/session-provider.tsx
@@ -31,7 +31,10 @@ export type SessionContextValue<R extends boolean = false> = R extends true
         }
 
 type SessionHandler = {
-  signin: (args?: { provider: ProviderType; callbackUrl?: string }) => void
+  signin: (args?: {
+    provider: ProviderType
+    callbackUrl?: string
+  }) => Promise<void>
   signout: () => Promise<void>
   signup: (nickname: string) => Promise<Session | null>
 }
@@ -142,7 +145,12 @@ export const useSession = <R extends boolean>(options?: {
     if (callbackUrl) {
       sessionStorage.setItem('callbackUrl', callbackUrl)
     }
-    signIn(provider, { callbackUrl })
+    return new Promise((resolve) => {
+      signIn(provider, { callbackUrl })
+      setTimeout(() => {
+        resolve()
+      }, 15000)
+    })
   }, [])
 
   const signout: SessionHandler['signout'] = useCallback(async () => {


### PR DESCRIPTION
### Issue No.

#58  NW-21
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [ㅌ]  1 공유받은 남의위키 링크 접속 -> 로그인 완료 -> 정원 먼저 노출 -> 몇초 후 설문 페이지로 리다이렉션

### 세부사항

- 로그인 함수를 Mutation으로 변경하여 `isPending` 상태에 따라 버튼을 활성화/비활성화 합니다.
- Pending Time은 임시로 15초로설정하였습니다.  ( 아래 첨부코드 참조 )
- csrf 페이지 내의 serverSideProps에서 `csrfCallbackUrl`을 props로 전달합니다.
- `csrfCallbackUrl`은 요청화면(요청이 시작된 화면) 으로 되돌아 가기전 선행되어야 하는 화면 입니다.
- 유저플로우 상 최대 스텝은 요청화면 - `csrfCallbackUrl` - sessionCallbackUrl 입니다

### 화면 결과 (캡쳐 첨부)

https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/73725736/5534774e-906b-4475-bce9-965fbe2c7dfd


<br/>