### PR TITLE
[NW-13, NW-33] 트리 카드 및 라우팅 QA 사항 추가

### DIFF
--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -66,9 +66,9 @@ const TreeCard = ({
         </div>
         <div className="card-back px-y w-full flex flex-col justify-center items-center ">
           <div className="w-full flex flex-col space-y-2 justify-center items-center m-auto">
-            <span className="text-body1-bold">{senderName}</span>
+            <span className="my-2 text-body1-bold">{senderName}</span>
             <Link className="z-20" href={`/answers?surveyId=${id}`}>
-              <button className="underline text-caption1-medium">
+              <button className="py-2 px-3 bg-gray-gray600 text-text-main-whiteFF rounded border text-caption1-medium">
                 자세히보기
               </button>
             </Link>

--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -52,7 +52,10 @@ const TreeCard = ({
     <motion.div
       id={id}
       variants={fadeInProps.variants}
-      className={cn('w-[104px] h-[110px] cursor-pointer relative')}
+      className={cn('w-[104px] h-[110px] cursor-pointer relative', {
+        'preserve-3d': isFlipped,
+      })}
+      style={{ transformStyle: 'preserve-3d' }}
       onClick={handleCardClick}
     >
       <div

--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -59,18 +59,20 @@ const TreeCard = ({
       onClick={handleCardClick}
     >
       <div
-        className={`card flex justify-center rounded-md w-full ${bgColor} ${isFlipped ? 'flipped' : ''}`}
+        className={`card flex justify-center w-full ${isFlipped ? 'flipped' : ''}`}
       >
         <div
           className={cn(
-            'card-front m-auto w-full flex flex-col justify-center items-center',
+            `card-front m-auto w-full flex flex-col justify-center items-center rounded-md ${bgColor}`,
           )}
         >
-          <div className="overflow-hidden flex justify-center items-center mt-3 z-0">
+          <div className="overflow-hidden flex justify-center items-center mt-3 z-0  ">
             {treeType.render(period as Period, relation as Relation)}
           </div>
         </div>
-        <div className="card-back px-y w-full flex flex-col justify-center items-center ">
+        <div
+          className={`card-back px-y w-full flex flex-col justify-center items-center rounded-md ${bgColor}`}
+        >
           <div className="w-full flex flex-col space-y-2 justify-center items-center m-auto">
             <span className="my-2 text-body1-bold">{senderName}</span>
             <Link

--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -44,6 +44,9 @@ const TreeCard = ({
   const handleCardClick = () => {
     onClick()
   }
+  const handleLinkClick = (e) => {
+    e.stopPropagation()
+  }
 
   return (
     <motion.div
@@ -67,7 +70,11 @@ const TreeCard = ({
         <div className="card-back px-y w-full flex flex-col justify-center items-center ">
           <div className="w-full flex flex-col space-y-2 justify-center items-center m-auto">
             <span className="my-2 text-body1-bold">{senderName}</span>
-            <Link className="z-20" href={`/answers?surveyId=${id}`}>
+            <Link
+              className="z-20"
+              href={`/answers?surveyId=${id}`}
+              onClick={handleLinkClick}
+            >
               <button className="py-2 px-3 bg-gray-gray600 text-text-main-whiteFF rounded border text-caption1-medium">
                 자세히보기
               </button>

--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -49,7 +49,7 @@ const TreeCard = ({
     <motion.div
       id={id}
       variants={fadeInProps.variants}
-      className={cn('w-[80px] h-[90px] cursor-pointer relative')}
+      className={cn('w-[104px] h-[110px] cursor-pointer relative')}
       onClick={handleCardClick}
     >
       <div

--- a/components/compositions/tree-card/index.tsx
+++ b/components/compositions/tree-card/index.tsx
@@ -44,7 +44,7 @@ const TreeCard = ({
   const handleCardClick = () => {
     onClick()
   }
-  const handleLinkClick = (e) => {
+  const handleLinkClick = (e: any) => {
     e.stopPropagation()
   }
 

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -24,6 +24,7 @@ export interface HeaderProps {
   bodyRef?: Ref<HTMLElement>
   className?: string
   options?: {
+    onCenterClick?: () => void
     onBackClick?: () => void
     showRight?: boolean
   }
@@ -42,6 +43,7 @@ const Header = ({
   className,
 }: HeaderProps) => {
   const { showRight, onBackClick } = options ?? { showRight: true }
+  const { onCenterClick } = options ?? { onCenterClick: () => {} }
   const headerRef = useRef<HTMLElement>(null)
   const router = useRouter()
 
@@ -118,7 +120,17 @@ const Header = ({
         )}
       </motion.button>
       <AnimatePresence mode="sync">
-        <motion.div {...fadeInProps} className="flex justify-center">
+        <motion.div
+          {...fadeInProps}
+          onClick={() =>
+            onCenterClick
+              ? onCenterClick()
+              : typeof center === 'undefined'
+                ? router.push('/garden')
+                : () => {}
+          }
+          className="flex justify-center"
+        >
           {center}
         </motion.div>
       </AnimatePresence>

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -37,7 +37,9 @@ const Page = () => {
         header={{
           options: {
             onBackClick: () => router.replace('/garden'),
+            onCenterClick: () => router.replace('/garden'),
             showRight: true,
+            
           },
         }}
         className={cn('h-calc-h overflow-y-scroll')}

--- a/pages/garden/index.tsx
+++ b/pages/garden/index.tsx
@@ -105,14 +105,14 @@ const Pages = () => {
               <motion.div
                 {...fadeInProps}
                 transition={{ staggerChildren: 0.03 }}
-                className="grid grid-cols-4 gap-2 "
+                className="grid grid-cols-3 gap-2 "
               >
                 {surveys?.pages.map((page, pageNo) =>
-                  pageNo === 0 && page.data.content.length < 20 ? (
+                  pageNo === 0 && page.data.content.length < 21 ? (
                     [
                       ...page.data.content,
                       ...Array.from(
-                        { length: 20 - page.data.content.length },
+                        { length: 21 - page.data.content.length },
                         (v) => null,
                       ),
                     ].map((item, index) =>
@@ -131,7 +131,7 @@ const Pages = () => {
                           variants={fadeInProps.variants}
                           key={`empty-${(pageNo + 1) * (index + 1)}`}
                         >
-                          <div className="flex justify-center items-center rounded w-[80px] h-[90px] bg-gray-gray50 border-dashed border ">
+                          <div className="flex justify-center items-center rounded w-[104px] h-[110px] bg-gray-gray50 border-dashed border ">
                             <svg
                               width="34"
                               height="34"
@@ -172,7 +172,7 @@ const Pages = () => {
                       key={`empty-${pageNo + 1}-container`}
                       {...fadeInProps}
                       transition={{ staggerChildren: 0.08 }}
-                      className="grid grid-cols-4 gap-2 "
+                      className="grid grid-cols-3 gap-2 "
                     >
                       {page.data.content.map((item, index) => (
                         <TreeCard
@@ -193,7 +193,7 @@ const Pages = () => {
               <motion.div
                 key={`empty-container`}
                 {...fadeInProps}
-                className="grid grid-cols-4 gap-2 "
+                className="grid grid-cols-3 gap-2 "
               >
                 {Array.from({ length: 40 }, (_, v) => v + 1).map((i) => (
                   <motion.div
@@ -201,7 +201,7 @@ const Pages = () => {
                     key={`loading-${i}`}
                     className="skeleton"
                   >
-                    <div className="flex justify-center items-center rounded w-[80px] h-[90px]"></div>
+                    <div className="flex justify-center items-center rounded w-[104px] h-[110px]"></div>
                   </motion.div>
                 ))}
               </motion.div>

--- a/pages/garden/index.tsx
+++ b/pages/garden/index.tsx
@@ -90,7 +90,7 @@ const Pages = () => {
           </h3>
         </div>
         <Link href="/dashboard">
-          <Button className="!w-fit px-3 py-4">내 결과 보기</Button>
+          <button className="!w-fit px-4 py-3 rounded-md text-body3-medium  text-main-green-green800 bg-main-green-green50 ">내 결과 보기</button>
         </Link>
       </div>
       <section className="bg-white">

--- a/styles/global.css
+++ b/styles/global.css
@@ -92,11 +92,13 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
 .card .card-back {
   transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
 }
 
 .card .card-front,
@@ -104,6 +106,9 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+
+  -webkit-transform-style: preserve-3d;
+  transform-style: preserve-3d;
 }
 html {
   -webkit-text-size-adjust: none;


### PR DESCRIPTION
### Issue No.

#66, #77


<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x] 1 대시보드 헤더 로고에 /garden 라우팅 추가
- [x] 2 카드 뒷면 자세히보기 클릭 이벤트 버블링 중지
- [x] 3 자세히보기 버튼, 내결과 보기 버튼 리디자인 적용
- [x] 4 정원 트리카드 3단구성 

### 세부사항

- ~~NW-33 QA 사항은 ios 버전 17 이하 (16)에서 일어나는 이슈로 확인되었습니다.  사파리, 크롬, 인스타/카카오 인앱브라우저에서 모두 동일하게 발생했고, 이 버전에 대한 대응은 논의해야할 사항일 거 같네요. 일단 3d 변환 적용과  `-webkit-backface-visibility: hidden;`를 .card > div 에도 적용했습니다....(이것도 안되면 진짜 모름 🤷ㅜ)~~
-> **bg-color 를 부모 div 제외 각각 card-front, card-back 에 적용한 결과 보이는 걸로 확인되었습니다 해결 완료 👍🏻**

- 자세히 보기 클릭 시 카드가 다시 앞면으로 돌아가는 걸 방지해 상위 엘리먼트로의 이벤트 전파 중지 로직 추가했습니다. 

- 이외 버튼들과 리 디자인된 구조 수정해두었습니다. 


### 화면 결과 (캡쳐 첨부)

https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/c0f0b283-2754-4991-a27f-8d32a5424b2f

https://github.com/dnd-side-project/dnd-10th-6-frontend/assets/82880442/3317f686-a80f-4064-94b1-df85d21765dc




<br/>